### PR TITLE
Make more robust

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -16,6 +16,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const core = __importStar(require("@actions/core"));
 const exec = __importStar(require("@actions/exec"));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -27,6 +28,7 @@ function run() {
             // will generally not work if triggered by a PR, which is a common
             // situation.
             // core.setFailed(error.message)
+            core.debug(error.message);
         }
     });
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,16 +16,17 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const core = __importStar(require("@actions/core"));
 const exec = __importStar(require("@actions/exec"));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            // await exec.exec('julia', ['--color=yes', '-e', 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'])
-            yield exec.exec('julia', ['--color=yes', '-e', 'using Pkg; Pkg.add(PackageSpec(name="Coverage", rev="master")); using Coverage; Coveralls.submit(process_folder())']);
+            yield exec.exec('julia', ['--color=yes', '-e', 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())']);
         }
         catch (error) {
-            core.setFailed(error.message);
+            // We are making errors non fatal for now because this for example
+            // will generally not work if triggered by a PR, which is a common
+            // situation.
+            // core.setFailed(error.message)
         }
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,10 @@ async function run() {
     try {
         await exec.exec('julia', ['--color=yes', '-e', 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'])
     } catch (error) {
-        core.setFailed(error.message)
+        // We are making errors non fatal for now because this for example
+        // will generally not work if triggered by a PR, which is a common
+        // situation.
+        // core.setFailed(error.message)
     }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ async function run() {
         // will generally not work if triggered by a PR, which is a common
         // situation.
         // core.setFailed(error.message)
+        core.debug(error.message)
     }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,7 @@ import * as exec from '@actions/exec'
 
 async function run() {
     try {
-        // await exec.exec('julia', ['--color=yes', '-e', 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'])
-        await exec.exec('julia', ['--color=yes', '-e', 'using Pkg; Pkg.add(PackageSpec(name="Coverage", rev="master")); using Coverage; Coveralls.submit(process_folder())'])
+        await exec.exec('julia', ['--color=yes', '-e', 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'])
     } catch (error) {
         core.setFailed(error.message)
     }


### PR DESCRIPTION
Two changes:
- Uses tagged version of Coverage.jl.
- Don't fail on errors because things will always error if triggered from a PR, which seems very common.